### PR TITLE
Update aicoe-ci config 

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -8,6 +8,7 @@ build:
    build-stratergy: Source
    build-source-script: "image:///opt/app-root/builder"
    base-image: quay.io/thoth-station/s2i-elyra-custom-notebook:latest
+   custom-tag: latest
    registry: quay.io
    registry-org: os-climate
    registry-project: aicoe-osc-demo


### PR DESCRIPTION
Adds `custom-tag: latest` to aicoe-ci config so that the `latest` tag is created on every image build.