### PR TITLE
updated schema of itr emissions table from demo1

### DIFF
--- a/notebooks/demo1/demo1-create-tables.ipynb
+++ b/notebooks/demo1/demo1-create-tables.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "For running the notebook in automation in an elyra pipeline, the environment variables can be updated in the notebook \"Properties\" in the pipeline UI or under `\"env_vars\"` in the `demo1.pipeline yaml` file.\n",
     "\n",
-    "For running the notebook in a local environment, we will define them as environment variables in a `credentials.env` file, and load them using dotenv. An example of what the contents of `credentials.env` could look like is shown below\n",
+    "For running the notebook in a local environment, we will define them as environment variables in a `credentials.env` file at the root of the project repository, and load them using dotenv. An example of what the contents of `credentials.env` could look like is shown below\n",
     "\n",
     "```\n",
     "# s3 credentials\n",
@@ -214,7 +214,12 @@
     "    ptypes = [str(e) for e in df.dtypes.to_list()]\n",
     "    stypes = [pandas_type_to_sql(e) for e in ptypes]\n",
     "    pz = list(zip(df.columns.to_list(), stypes))\n",
-    "    return \",\\n\".join([\"    {n} {t}\".format(n=e[0], t=e[1]) for e in pz])"
+    "    return \",\\n\".join([\"    {n} {t}\".format(n=e[0], t=e[1]) for e in pz])\n",
+    "\n",
+    "# Convert GHG values with string representation of numbers to float\n",
+    "def str_w_spaces_to_numeric(df, col):\n",
+    "    df[col] = df[col].str.replace(' ','').str.replace(',','')\n",
+    "    df[col] = df[col].astype('float').astype('Float64')"
    ]
   },
   {
@@ -235,6 +240,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "751ce99d-9115-41fb-bd81-68dffedac954",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Modify GHG emissions columns to be numeric so plotting charts becomes easier\n",
+    "str_w_spaces_to_numeric(df_emissions, 'base_year_ghg_emissions_s1_tco2e')\n",
+    "str_w_spaces_to_numeric(df_emissions, 'base_year_ghg_emissions_s1s2_tco2e')\n",
+    "str_w_spaces_to_numeric(df_emissions, 'base_year_ghg_emissions_s3_tco2e')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "id": "c5230c3f",
    "metadata": {},
    "outputs": [
@@ -258,12 +276,12 @@
       " 8   base_year                           19 non-null     Int64  \n",
       " 9   end_year                            19 non-null     Int64  \n",
       " 10  start_year                          19 non-null     Int64  \n",
-      " 11  base_year_ghg_emissions_s1_tco2e    1 non-null      string \n",
-      " 12  base_year_ghg_emissions_s1s2_tco2e  14 non-null     string \n",
-      " 13  base_year_ghg_emissions_s3_tco2e    18 non-null     string \n",
+      " 11  base_year_ghg_emissions_s1_tco2e    1 non-null      Float64\n",
+      " 12  base_year_ghg_emissions_s1s2_tco2e  14 non-null     Float64\n",
+      " 13  base_year_ghg_emissions_s3_tco2e    18 non-null     Float64\n",
       " 14  achieved_reduction                  19 non-null     Float64\n",
-      "dtypes: Float64(4), Int64(4), string(7)\n",
-      "memory usage: 2.5 KB\n"
+      "dtypes: Float64(7), Int64(4), string(4)\n",
+      "memory usage: 2.6 KB\n"
      ]
     }
    ],
@@ -284,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "72b3795f",
    "metadata": {},
    "outputs": [],
@@ -303,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "fd04263e",
    "metadata": {},
    "outputs": [],
@@ -332,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "950868a0",
    "metadata": {},
    "outputs": [],
@@ -351,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "0d4860b8",
    "metadata": {},
    "outputs": [
@@ -361,7 +379,7 @@
        "[[True]]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -373,7 +391,7 @@
     "# or on the pandas data-frame itself before we write it out\n",
     "schema = generate_table_schema_pairs(df_emissions)\n",
     "\n",
-    "tabledef = \"\"\"create table if not exists osc_datacommons_dev.urgentem.itr_emissions_1(\n",
+    "tabledef = \"\"\"create table if not exists osc_datacommons_dev.urgentem.itr_emissions_1_v2(\n",
     "{schema}\n",
     ") with (\n",
     "    format = 'parquet',\n",
@@ -392,7 +410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "b235749f",
    "metadata": {},
    "outputs": [
@@ -402,7 +420,7 @@
        "[[True]]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -433,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "ee568250",
    "metadata": {},
    "outputs": [
@@ -452,25 +470,25 @@
        " 2020,\n",
        " 2015,\n",
        " None,\n",
-       " ' 59,132 ',\n",
-       " ' 295,660 ',\n",
+       " 59132.0,\n",
+       " 295660.0,\n",
        " 1.0]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "## Check if table 1 is there\n",
-    "cur.execute(\"select * from osc_datacommons_dev.urgentem.itr_emissions_1 LIMIT 5\")\n",
+    "cur.execute(\"select * from osc_datacommons_dev.urgentem.itr_emissions_1_v2 LIMIT 5\")\n",
     "cur.fetchall()[1]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "53f526a8",
    "metadata": {},
    "outputs": [
@@ -494,7 +512,7 @@
        " 'Inferred - Average - Industry winsor']"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -507,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "8448bc10-03a7-4339-86ec-96506d410fb0",
    "metadata": {},
    "outputs": [],
@@ -550,17 +568,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "5e7059c9-1e3c-449a-8d69-f3f2f4999083",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "512"
+       "515"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -583,7 +601,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -597,7 +615,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In this PR, we update the schema of table 1 in demo1 and convert certain string represented numeric columns to numeric, so that we can plot visualizations from them.

We face an issue overwriting the table on trino as it was created by Erik, hence we are creating a new table version of table 1 and are going to use the same for visualizations.

closes #38 