### PR TITLE
Add Dockerfile for custom image

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -5,11 +5,10 @@ check:
   - thoth-build
 # Uncomment following lines to build a public image of this repo
 build:
-   build-stratergy: Source
-   build-source-script: "image:///opt/app-root/builder"
-   base-image: quay.io/thoth-station/s2i-elyra-custom-notebook:latest
-   custom-tag: latest
-   registry: quay.io
-   registry-org: os-climate
-   registry-project: aicoe-osc-demo
-   registry-secret: os-climate-pusher-secret
+  build-stratergy: Dockerfile
+  dockerfile-path: Dockerfile
+  custom-tag: latest
+  registry: quay.io
+  registry-org: os-climate
+  registry-project: aicoe-osc-demo
+  registry-secret: os-climate-pusher-secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM quay.io/thoth-station/s2i-elyra-custom-notebook:latest
+LABEL "name"="aicoe-osc-demo" \
+      "io.openshift.s2i.build.image"="quay.io/thoth-station/s2i-elyra-custom-notebook:latest" \
+      "io.openshift.s2i.scripts-url"="image:///opt/app-root/builder"
+
+ENV JUPYTER_ENABLE_LAB="1" \
+    ENABLE_MICROPIPENV="1" \
+    THAMOS_RUNTIME_ENVIRONMENT="" \
+    THOTH_ADVISE="0" \
+    THOTH_ERROR_FALLBACK="1" \
+    THOTH_DRY_RUN="1" \
+    THAMOS_DEBUG="0" \
+    THAMOS_VERBOSE="1" \
+    THOTH_PROVENANCE_CHECK="0"
+
+USER root
+
+# Adding the poppler utils dependency
+RUN yum install -y poppler-utils
+RUN yum install -y java-1.8.0-openjdk
+
+# Copying in source code
+COPY . /tmp/src
+# Change file ownership to the assemble user. Builder image must support chown command.
+RUN chown -R 1001:0 /tmp/src
+USER 1001
+# Assemble script sourced from builder image based on user input or image metadata.
+# If this file does not exist in the image, the build will fail.
+RUN /opt/app-root/builder/assemble
+# Run script sourced from builder image based on user input or image metadata.
+# If this file does not exist in the image, the build will fail.
+
+CMD /opt/app-root/builder/run


### PR DESCRIPTION
## Related issue
Fixes #45 

## Description

- This PR adds a Dockerfile for custom linux dependencies required in the project image. The PR also updates the build strategy in .aicoe.yaml. 
- The dockerfile has yum installs for poppler and java required to run the jotebooks.
- Tested the image with a local docker build

