### PR TITLE
Update demo2 elyra pipeline runtime image

### DIFF
--- a/notebooks/demo2/demo2.pipeline
+++ b/notebooks/demo2/demo2.pipeline
@@ -14,7 +14,7 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "pdf_table_extraction.ipynb",
-            "runtime_image": "quay.io/kachau/aicoe-osc-demo:v0.3",
+            "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
               "S3_ACCESS_KEY=",
               "S3_SECRET_KEY=",
@@ -73,7 +73,7 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "pdf_table_curation.ipynb",
-            "runtime_image": "quay.io/kachau/aicoe-osc-demo:v0.3",
+            "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
               "S3_ACCESS_KEY=",
               "S3_SECRET_KEY=",
@@ -138,7 +138,7 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "pdf_text_extraction.ipynb",
-            "runtime_image": "quay.io/kachau/aicoe-osc-demo:v0.3",
+            "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
               "S3_ACCESS_KEY=",
               "S3_SECRET_KEY=",
@@ -196,7 +196,7 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "pdf_text_curation.ipynb",
-            "runtime_image": "quay.io/kachau/aicoe-osc-demo:v0.3",
+            "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
               "S3_ACCESS_KEY=",
               "S3_SECRET_KEY=",


### PR DESCRIPTION
Related to #52

The elyra pipeline definition added in #76 uses an image that was created from my fork of this repo. But the [latest release](https://github.com/os-climate/aicoe-osc-demo/releases/tag/v0.8.0) created an image of this upstream repo, which now includes the required changes for the pipeline to run.

So this PR updates the elyra pipeline to use this image instead of the one created from the fork.