### PR TITLE
Fix Image env. for pipeline to work

### DIFF
--- a/src/data/s3_communication.py
+++ b/src/data/s3_communication.py
@@ -139,7 +139,8 @@ class S3Communication(object):
             # download files at the root of this prefix
             for file in result.get("Contents", []):
                 dest_filename = osp.basename(file.get("Key"))
-                dest_pathname = osp.join(destination_dir, dest_filename)
-                if not osp.exists(osp.dirname(dest_pathname)):
-                    os.makedirs(osp.dirname(dest_pathname))
-                self.download_file_from_s3(dest_pathname, s3_prefix, dest_filename)
+                if dest_filename:
+                    dest_pathname = osp.join(destination_dir, dest_filename)
+                    if not osp.exists(osp.dirname(dest_pathname)):
+                        os.makedirs(osp.dirname(dest_pathname))
+                    self.download_file_from_s3(dest_pathname, s3_prefix, dest_filename)


### PR DESCRIPTION
This PR add changes required to run the inference pipeline using the demo image. 
The s3 communication file was giving an error while downloading the pdfs from the s3 pdf folder, so this PR adds the edge case handling required to fix the error.