### PR TITLE
Add demo3 for KPI Inference Model

### DIFF
--- a/notebooks/demo3/demo3-create-tables.ipynb
+++ b/notebooks/demo3/demo3-create-tables.ipynb
@@ -1,0 +1,548 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "395f44cf",
+   "metadata": {},
+   "source": [
+    "# Demo 3 - Data Ingestion\n",
+    "\n",
+    "This notebook reads the inference from ceph s3 storage for demo2 and will ingest these inference as a table to trino. These tables will be used for creating visualizations using Apache Superset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd4bb47d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import re\n",
+    "import pathlib\n",
+    "from dotenv import load_dotenv\n",
+    "import boto3\n",
+    "import trino\n",
+    "import pandas as pd\n",
+    "import glob\n",
+    "from src.data.s3_communication import S3Communication, S3FileType"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f2fe317",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Injecting Credentials\n",
+    "\n",
+    "In order to run this notebook, we need credentials to connect with S3 storage to retrieve data and the Trino server to create tables.\n",
+    "\n",
+    "In an automated environment, the credentials can be specified in a pipeline's environment variables or through Openshift secrets.\n",
+    "\n",
+    "For running the notebook in a local environment, we will define them as environment variables in a `credentials.env` file at the root of the project repository, and load them using dotenv. An example of what the contents of `credentials.env` could look like is shown below\n",
+    "\n",
+    "```\n",
+    "# s3 credentials\n",
+    "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com\n",
+    "S3_BUCKET=ocp-odh-os-demo-s3\n",
+    "S3_ACCESS_KEY=xxx\n",
+    "S3_SECRET_KEY=xxx\n",
+    "\n",
+    "# trino credentials\n",
+    "TRINO_USER=xxx\n",
+    "TRINO_PASSWD=xxx\n",
+    "TRINO_HOST=trino-secure-odh-trino.apps.odh-cl1.apps.os-climate.org\n",
+    "TRINO_PORT=443\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a84efa52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load credentials\n",
+    "dotenv_dir = \"/opt/app-root/src/aicoe-osc-demo\"\n",
+    "dotenv_path = pathlib.Path(dotenv_dir) / \"credentials.env\"\n",
+    "if os.path.exists(dotenv_path):\n",
+    "    load_dotenv(dotenv_path=dotenv_path, override=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d78368e2",
+   "metadata": {},
+   "source": [
+    "## Read Raw Data from S3\n",
+    "\n",
+    "First, we will read some sample data from s3. We will format the column data types to ensure they can be understood by Trino, as well as rename the columns so that they are compatible with SQL naming conventions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "466e8eaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# init s3 connector\n",
+    "s3c = S3Communication(\n",
+    "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
+    "    aws_access_key_id=os.getenv(\"S3_ACCESS_KEY\"),\n",
+    "    aws_secret_access_key=os.getenv(\"S3_SECRET_KEY\"),\n",
+    "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "beacf8ea-ce2b-4ecf-8695-ef31e5ca14ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if os.getenv(\"AUTOMATION\"):\n",
+    "    ROOT =  pathlib.Path(\"/opt/app-root\")\n",
+    "else:\n",
+    "    ROOT = pathlib.Path(\".\").resolve().parent.parent\n",
+    "DATA_FOLDER = ROOT / \"data\"\n",
+    "DATA_S3_PREFIX = \"corpdata/ESG\"\n",
+    "INFER_SAMPLE_S3_PREFIX = f\"{DATA_S3_PREFIX}/pipeline_run/samples_4/infer_KPI\"\n",
+    "BASE_INFER_KPI_TABLE_S3_PREFIX = f\"{DATA_S3_PREFIX}/KPI_table\"\n",
+    "DATA_INFER_KPI = f\"{DATA_FOLDER}/infer_kpi\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "269aa2fb-e410-49b5-a80e-42fba3874604",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if os.getenv(\"AUTOMATION\"):\n",
+    "    if not os.path.exists(DATA_INFER_KPI):\n",
+    "        pathlib.Path(DATA_INFER_KPI).mkdir(parents=True, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f4f4bdf6-8b20-42a4-9a74-552bfbcec2f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pdf_name</th>\n",
+       "      <th>kpi</th>\n",
+       "      <th>kpi_id</th>\n",
+       "      <th>answer</th>\n",
+       "      <th>page</th>\n",
+       "      <th>paragraph</th>\n",
+       "      <th>source</th>\n",
+       "      <th>score</th>\n",
+       "      <th>no_ans_score</th>\n",
+       "      <th>no_answer_score_plus_boost</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>90044053_Fisher &amp; Paykel Hl_2017-11-07</td>\n",
+       "      <td>In which year was the annual report or the sus...</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>2017</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Corporate Responsibility and Sustainability Re...</td>\n",
+       "      <td>Text</td>\n",
+       "      <td>11.549626</td>\n",
+       "      <td>-8.78702</td>\n",
+       "      <td>-23.78702</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>90044053_Fisher &amp; Paykel Hl_2017-11-07</td>\n",
+       "      <td>In which year was the annual report or the sus...</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>2017</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Corporate Responsibility and Sustainability Re...</td>\n",
+       "      <td>Text</td>\n",
+       "      <td>11.549626</td>\n",
+       "      <td>-8.78702</td>\n",
+       "      <td>-23.78702</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>90044053_Fisher &amp; Paykel Hl_2017-11-07</td>\n",
+       "      <td>In which year was the annual report or the sus...</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>2017</td>\n",
+       "      <td>3</td>\n",
+       "      <td>Corporate Responsibility and Sustainability Re...</td>\n",
+       "      <td>Text</td>\n",
+       "      <td>11.549626</td>\n",
+       "      <td>-8.78702</td>\n",
+       "      <td>-23.78702</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>90044053_Fisher &amp; Paykel Hl_2017-11-07</td>\n",
+       "      <td>In which year was the annual report or the sus...</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>2017</td>\n",
+       "      <td>4</td>\n",
+       "      <td>Corporate Responsibility and Sustainability Re...</td>\n",
+       "      <td>Text</td>\n",
+       "      <td>11.549626</td>\n",
+       "      <td>-8.78702</td>\n",
+       "      <td>-23.78702</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>90044053_Fisher &amp; Paykel Hl_2017-11-07</td>\n",
+       "      <td>What is the base year for carbon reduction com...</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>9</td>\n",
+       "      <td>In 2015, the United Nations established the Su...</td>\n",
+       "      <td>Text</td>\n",
+       "      <td>-3.63974</td>\n",
+       "      <td>13.193857</td>\n",
+       "      <td>-1.806143</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 pdf_name  \\\n",
+       "0  90044053_Fisher & Paykel Hl_2017-11-07   \n",
+       "1  90044053_Fisher & Paykel Hl_2017-11-07   \n",
+       "2  90044053_Fisher & Paykel Hl_2017-11-07   \n",
+       "3  90044053_Fisher & Paykel Hl_2017-11-07   \n",
+       "4  90044053_Fisher & Paykel Hl_2017-11-07   \n",
+       "\n",
+       "                                                 kpi  kpi_id answer  page  \\\n",
+       "0  In which year was the annual report or the sus...    <NA>   2017     1   \n",
+       "1  In which year was the annual report or the sus...    <NA>   2017     2   \n",
+       "2  In which year was the annual report or the sus...    <NA>   2017     3   \n",
+       "3  In which year was the annual report or the sus...    <NA>   2017     4   \n",
+       "4  What is the base year for carbon reduction com...    <NA>   2015     9   \n",
+       "\n",
+       "                                           paragraph source      score  \\\n",
+       "0  Corporate Responsibility and Sustainability Re...   Text  11.549626   \n",
+       "1  Corporate Responsibility and Sustainability Re...   Text  11.549626   \n",
+       "2  Corporate Responsibility and Sustainability Re...   Text  11.549626   \n",
+       "3  Corporate Responsibility and Sustainability Re...   Text  11.549626   \n",
+       "4  In 2015, the United Nations established the Su...   Text   -3.63974   \n",
+       "\n",
+       "   no_ans_score  no_answer_score_plus_boost  \n",
+       "0      -8.78702                   -23.78702  \n",
+       "1      -8.78702                   -23.78702  \n",
+       "2      -8.78702                   -23.78702  \n",
+       "3      -8.78702                   -23.78702  \n",
+       "4     13.193857                   -1.806143  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Download a sample dataset file from s3\n",
+    "s3c.download_files_in_prefix_to_dir(\n",
+    "  s3_prefix=INFER_SAMPLE_S3_PREFIX,\n",
+    "  destination_dir=DATA_INFER_KPI\n",
+    ")\n",
+    "\n",
+    "all_files = glob.glob(DATA_INFER_KPI + \"/*.csv\")\n",
+    "list_of_files =  []\n",
+    "\n",
+    "for filename in all_files:\n",
+    "    df = pd.read_csv(filename, index_col=None, header=0).convert_dtypes().drop(columns=['Unnamed: 0'],axis=1)\n",
+    "    list_of_files.append(df)\n",
+    "\n",
+    "preds_kpi = pd.concat(list_of_files, axis=0, ignore_index=True)\n",
+    "\n",
+    "len_preds_kpi = len(preds_kpi)\n",
+    "\n",
+    "# convert columns to specific data types\n",
+    "preds_kpi = preds_kpi.convert_dtypes().drop(['index'], axis =1)\n",
+    "preds_kpi.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f87ac21e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Author: Erik Erlandson <eje@redhat.com>\n",
+    "\n",
+    "_p2smap = {\"string\": \"varchar\", \"Float64\": \"double\", \"Int64\": \"bigint\"}\n",
+    "\n",
+    "def pandas_type_to_sql(pt):\n",
+    "    st = _p2smap.get(pt)\n",
+    "    if st is not None:\n",
+    "        return st\n",
+    "    raise ValueError(\"unexpected pandas column type '{pt}'\".format(pt=pt))\n",
+    "\n",
+    "\n",
+    "# add ability to specify optional dict for specific fields?\n",
+    "# if column name is present, use specified value?\n",
+    "def generate_table_schema_pairs(df):\n",
+    "    ptypes = [str(e) for e in df.dtypes.to_list()]\n",
+    "    stypes = [pandas_type_to_sql(e) for e in ptypes]\n",
+    "    pz = list(zip(df.columns.to_list(), stypes))\n",
+    "    return \",\\n\".join([\"    {n} {t}\".format(n=e[0], t=e[1]) for e in pz])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c5230c3f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 189 entries, 0 to 188\n",
+      "Data columns (total 10 columns):\n",
+      " #   Column                      Non-Null Count  Dtype  \n",
+      "---  ------                      --------------  -----  \n",
+      " 0   pdf_name                    189 non-null    string \n",
+      " 1   kpi                         189 non-null    string \n",
+      " 2   kpi_id                      0 non-null      Int64  \n",
+      " 3   answer                      189 non-null    string \n",
+      " 4   page                        153 non-null    Int64  \n",
+      " 5   paragraph                   153 non-null    string \n",
+      " 6   source                      189 non-null    string \n",
+      " 7   score                       189 non-null    Float64\n",
+      " 8   no_ans_score                153 non-null    Float64\n",
+      " 9   no_answer_score_plus_boost  153 non-null    Float64\n",
+      "dtypes: Float64(3), Int64(2), string(5)\n",
+      "memory usage: 15.8 KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# a way to examine the structure of a pandas data frame\n",
+    "preds_kpi.info(verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4078824e",
+   "metadata": {},
+   "source": [
+    "## Save Processed Data to S3\n",
+    "\n",
+    "Now that our data is in a form ingestible by Trino, we will upload it back into our s3 bucket. This will be the data source for our Trino table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "72b3795f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ResponseMetadata': {'RequestId': '70448FZYCTWQV8ZA',\n",
+       "  'HostId': 'mcxQ0crdCSCy09rwCPYxOLgwFoCAHqmtrhAKCCpTtayXKRngi9ArmmFR0S2knKaOG/ZPWqsQsdk=',\n",
+       "  'HTTPStatusCode': 200,\n",
+       "  'HTTPHeaders': {'x-amz-id-2': 'mcxQ0crdCSCy09rwCPYxOLgwFoCAHqmtrhAKCCpTtayXKRngi9ArmmFR0S2knKaOG/ZPWqsQsdk=',\n",
+       "   'x-amz-request-id': '70448FZYCTWQV8ZA',\n",
+       "   'date': 'Fri, 12 Nov 2021 17:02:14 GMT',\n",
+       "   'etag': '\"370914c0092dd4d25974260af03341de\"',\n",
+       "   'server': 'AmazonS3',\n",
+       "   'content-length': '0'},\n",
+       "  'RetryAttempts': 0},\n",
+       " 'ETag': '\"370914c0092dd4d25974260af03341de\"'}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# parquet has multiple options for appending or updating data\n",
+    "# including adding new files, or appending, sharding directory trees, etc\n",
+    "s3c.upload_df_to_s3(\n",
+    "    preds_kpi,\n",
+    "    s3_prefix=BASE_INFER_KPI_TABLE_S3_PREFIX,\n",
+    "    s3_key=\"kpi_processed.parquet\",\n",
+    "    filetype=S3FileType.PARQUET,\n",
+    "    index=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72b8af31",
+   "metadata": {},
+   "source": [
+    "## Create a Table on Trino\n",
+    "\n",
+    "Finally, we will create a table in our Trino database that uses the parquet files we uploaded in the previous section as the data source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "950868a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use trino password env-var to hold token values\n",
+    "JWT_TOKEN = os.environ['TRINO_PASSWD']\n",
+    "conn = trino.dbapi.connect(\n",
+    "    host=os.environ['TRINO_HOST'],\n",
+    "    port=os.environ['TRINO_PORT'],\n",
+    "    user=os.environ['TRINO_USER'],\n",
+    "    http_scheme='https',\n",
+    "    auth=trino.auth.JWTAuthentication(JWT_TOKEN),\n",
+    ")\n",
+    "cur = conn.cursor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0d4860b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[True]]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# generate a sql schema that will correspond to the data types\n",
+    "# of columns in the pandas DF\n",
+    "# to-do: add some mechanisms for overriding types, either here\n",
+    "# or on the pandas data-frame itself before we write it out\n",
+    "schema = generate_table_schema_pairs(preds_kpi)\n",
+    "\n",
+    "tabledef = \"\"\"create table if not exists osc_datacommons_dev.urgentem.infer_kpi(\n",
+    "{schema}\n",
+    ") with (\n",
+    "    format = 'parquet',\n",
+    "    external_location = 's3a://{s3_bucket}/corpdata/ESG/KPI_table/'\n",
+    ")\"\"\".format(\n",
+    "    schema=schema,\n",
+    "    s3_bucket=os.environ[\"S3_BUCKET\"],\n",
+    ")\n",
+    "# tables created externally may not show up immediately in cloud-beaver\n",
+    "cur.execute(tabledef)\n",
+    "cur.fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ee568250",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['90044053_Fisher & Paykel Hl_2017-11-07',\n",
+       " 'In which year was the annual report or the sustainability report published?',\n",
+       " None,\n",
+       " '2017',\n",
+       " 2,\n",
+       " 'Corporate Responsibility and Sustainability Report 2017Fisher & Paykel Healthcare Corporation Limited',\n",
+       " 'Text',\n",
+       " 11.549626350402832,\n",
+       " -8.787019729614258,\n",
+       " -23.787019729614254]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "## Check if infer_kpi table is there\n",
+    "cur.execute(\"select * from osc_datacommons_dev.urgentem.infer_kpi LIMIT 5\")\n",
+    "cur.fetchall()[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85d0d0a0",
+   "metadata": {},
+   "source": [
+    "# Conclusion\n",
+    "\n",
+    "In this notebook, we read inference for KPI sustainability report, 2019 which follows the same format as the output of the KPI Inference model in Demo 2. After reading the report, we automatically infer the data schema from the report, preprocess it and create a table in trino that could be used for visualization in Apache Superset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66ac2261-fe94-4171-b20c-189d75137af8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/demo3/demo3.pipeline
+++ b/notebooks/demo3/demo3.pipeline
@@ -1,0 +1,83 @@
+{
+  "doc_type": "pipeline",
+  "version": "3.0",
+  "json_schema": "http://api.dataplatform.ibm.com/schemas/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json",
+  "id": "37b66992-65ca-4b55-889b-ffdfbb558294",
+  "primary_pipeline": "4de372ef-a37f-4278-9063-2cb5b8b8a2af",
+  "pipelines": [
+    {
+      "id": "4de372ef-a37f-4278-9063-2cb5b8b8a2af",
+      "nodes": [
+        {
+          "id": "8efee0dd-5cd2-4116-a3f1-f639b62a910d",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "filename": "demo3-create-tables.ipynb",
+            "runtime_image": "quay.io/os-climate/aicoe-osc-demo:v0.11.0",
+            "env_vars": [
+              "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
+              "S3_ACCESS_KEY=",
+              "S3_SECRET_KEY=",
+              "S3_BUCKET=ocp-odh-os-demo-s3",
+              "AUTOMATION=1",
+              "TRINO_PASSWD=",
+              "TRINO_HOST=trino-secure-odh-trino.apps.odh-cl1.apps.os-climate.org",
+              "TRINO_PORT=443",
+              "TRINO_USER="
+            ],
+            "include_subdirectories": false,
+            "invalidNodeError": null,
+            "outputs": [],
+            "dependencies": [],
+            "cpu": 1,
+            "memory": 8,
+            "ui_data": {
+              "label": "demo3-create-tables.ipynb",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 215,
+              "y_pos": 115,
+              "description": "Notebook file"
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              }
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "app_data": {
+        "ui_data": {
+          "comments": []
+        },
+        "version": 3
+      },
+      "runtime_ref": ""
+    }
+  ],
+  "schemas": []
+}


### PR DESCRIPTION
This PR resolves #94 and adds a modified version of `demo1-create-tables.ipynb` to push demo 2 prediction results CSV into trino.

The raw data from the [csv](https://github.com/os-climate/corporate_data_pipeline/blob/main/Allianz_NLP/data/infer/KPI_EXTRACTION/ESG/Text/sustainability-report-2019_predictions_kpi.csv) is now ingested to Trino.

![image](https://user-images.githubusercontent.com/26301643/141165863-a1d309d6-b811-47c5-8caa-2a952ea4d8bf.png)


Pipeline run to ensure demo3 notebook also runs in automation:

http://ml-pipeline-ui-kubeflow.apps.odh-cl1.apps.os-climate.org/pipeline/#/runs/details/b1a77585-1938-4cf9-b729-dd369b1ef377 
![image](https://user-images.githubusercontent.com/32435206/141506151-b4788c8f-a8fa-42cb-8334-cc4bc855fedb.png)

