### PR TITLE
modify notebooks and pipeline to use openshift secret

### DIFF
--- a/notebooks/demo1/README.md
+++ b/notebooks/demo1/README.md
@@ -64,9 +64,10 @@ Insert all inputs for the Runtime"
 - Kubeflow Pipeline API Endpoint: `http://ml-pipeline-ui-kubeflow.apps.odh-cl1.apps.os-climate.org/pipeline`
 - Kubeflow Pipeline Engine: `Tekton`
 - Cloud Object Storage Endpoint: `S3_ENDPOINT`
-- Cloud Object Storage Username: `S3_ACCESS_KEY`
-- Cloud Object Storage Password: `S3_SECRET_KEY`
+- Cloud Object Storage Username: `AWS_ACCESS_KEY_ID`
+- Cloud Object Storage Password: `AWS_SECRET_ACCESS_KEY`
 - Cloud Object Storage Bucket Name: `S3_BUCKET`
+- Cloud Object Storage Credentials Secret: `S3_SECRET`
 
 #### Set up Notebook Properties
 
@@ -78,7 +79,7 @@ To trigger this pipeline, you need to make sure that the node properties for eac
 
 ![Set up Notebook Properties](../../docs/assets/demo1-notebook-properties.png)
 
-You need to fill in the cloud object storage bucket credentials like `S3_ENDPOINT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET`, and the Trino database access credentials like `TRINO_USER`, `TRINO_PASSWD`, `TRINO_HOST`, `TRINO_PORT`
+You need to fill in the cloud object storage bucket credentials like `S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `S3_BUCKET`, and the Trino database access credentials like `TRINO_USER`, `TRINO_PASSWD`, `TRINO_HOST`, `TRINO_PORT`. Please note, if you are using the Cloud Object Storage Credentials Secret field in the Kubeflow Pipelines Runtime configuration, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` can be omitted from the notebook properties as kubeflow is automatically able to read the encrypted credentials from the secret defined in OpenShift.
 
 #### Run Pipeline
 

--- a/notebooks/demo1/demo1-create-tables.ipynb
+++ b/notebooks/demo1/demo1-create-tables.ipynb
@@ -51,8 +51,8 @@
     "# s3 credentials\n",
     "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com\n",
     "S3_BUCKET=ocp-odh-os-demo-s3\n",
-    "S3_ACCESS_KEY=xxx\n",
-    "S3_SECRET_KEY=xxx\n",
+    "AWS_ACCESS_KEY_ID=xxx\n",
+    "AWS_SECRET_ACCESS_KEY=xxx\n",
     "\n",
     "# trino credentials\n",
     "TRINO_USER=xxx\n",
@@ -108,8 +108,8 @@
     "s3 = boto3.client(\n",
     "    service_name=\"s3\",\n",
     "    endpoint_url=os.environ[\"S3_ENDPOINT\"],\n",
-    "    aws_access_key_id=os.environ[\"S3_ACCESS_KEY\"],\n",
-    "    aws_secret_access_key=os.environ[\"S3_SECRET_KEY\"],\n",
+    "    aws_access_key_id=os.environ[\"AWS_ACCESS_KEY_ID\"],\n",
+    "    aws_secret_access_key=os.environ[\"AWS_SECRET_ACCESS_KEY\"],\n",
     ")"
    ]
   },

--- a/notebooks/demo1/demo1.pipeline
+++ b/notebooks/demo1/demo1.pipeline
@@ -18,8 +18,6 @@
             "env_vars": [
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
               "S3_BUCKET=ocp-odh-os-demo-s3",
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "TRINO_USER=",
               "TRINO_PASSWD=",
               "TRINO_HOST=trino-secure-odh-trino.apps.odh-cl1.apps.os-climate.org",
@@ -78,8 +76,6 @@
             "env_vars": [
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
               "S3_BUCKET=ocp-odh-os-demo-s3",
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "TRINO_USER=",
               "TRINO_PASSWD=",
               "TRINO_HOST=trino-secure-odh-trino.apps.odh-cl1.apps.os-climate.org",

--- a/notebooks/demo2/create_results_table.ipynb
+++ b/notebooks/demo2/create_results_table.ipynb
@@ -48,8 +48,8 @@
     "# s3 credentials\n",
     "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com\n",
     "S3_BUCKET=ocp-odh-os-demo-s3\n",
-    "S3_ACCESS_KEY=xxx\n",
-    "S3_SECRET_KEY=xxx\n",
+    "AWS_ACCESS_KEY_ID=xxx\n",
+    "AWS_SECRET_ACCESS_KEY=xxx\n",
     "\n",
     "# trino credentials\n",
     "TRINO_USER=xxx\n",
@@ -93,8 +93,8 @@
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
     "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_SECRET_KEY\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
     "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]

--- a/notebooks/demo2/infer_kpi.ipynb
+++ b/notebooks/demo2/infer_kpi.ipynb
@@ -61,8 +61,8 @@
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
     "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_SECRET_KEY\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
     "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]

--- a/notebooks/demo2/infer_relevance.ipynb
+++ b/notebooks/demo2/infer_relevance.ipynb
@@ -63,8 +63,8 @@
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
     "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_SECRET_KEY\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
     "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]

--- a/notebooks/demo2/inference.pipeline
+++ b/notebooks/demo2/inference.pipeline
@@ -17,8 +17,6 @@
             "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "S3_BUCKET=ocp-odh-os-demo-s3",
               "AUTOMATION=1"
             ],
@@ -76,8 +74,6 @@
             "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "S3_BUCKET=ocp-odh-os-demo-s3",
               "AUTOMATION=1"
             ],
@@ -144,8 +140,6 @@
             "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "S3_BUCKET=ocp-odh-os-demo-s3",
               "AUTOMATION=1"
             ],
@@ -213,8 +207,6 @@
             "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "S3_BUCKET=ocp-odh-os-demo-s3",
               "AUTOMATION=1",
               "TRINO_PASSWD=",

--- a/notebooks/demo2/pdf_table_curation.ipynb
+++ b/notebooks/demo2/pdf_table_curation.ipynb
@@ -81,8 +81,8 @@
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
     "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_SECRET_KEY\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
     "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]

--- a/notebooks/demo2/pdf_text_curation.ipynb
+++ b/notebooks/demo2/pdf_text_curation.ipynb
@@ -72,8 +72,8 @@
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
     "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_SECRET_KEY\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
     "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]

--- a/notebooks/demo2/pdf_text_extraction.ipynb
+++ b/notebooks/demo2/pdf_text_extraction.ipynb
@@ -72,8 +72,8 @@
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
     "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_SECRET_KEY\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
     "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]

--- a/notebooks/demo2/preprocessing.pipeline
+++ b/notebooks/demo2/preprocessing.pipeline
@@ -16,8 +16,6 @@
             "filename": "pdf_table_extraction.ipynb",
             "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
               "S3_BUCKET=ocp-odh-os-demo-s3",
               "AUTOMATION=1"
@@ -76,8 +74,6 @@
             "filename": "pdf_table_curation.ipynb",
             "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
               "S3_BUCKET=ocp-odh-os-demo-s3",
               "AUTOMATION=1"
@@ -142,8 +138,6 @@
             "filename": "pdf_text_extraction.ipynb",
             "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
               "S3_BUCKET=ocp-odh-os-demo-s3",
               "AUTOMATION=1"
@@ -201,8 +195,6 @@
             "filename": "pdf_text_curation.ipynb",
             "runtime_image": "quay.io/os-climate/aicoe-osc-demo:latest",
             "env_vars": [
-              "S3_ACCESS_KEY=",
-              "S3_SECRET_KEY=",
               "S3_ENDPOINT=https://s3.us-east-1.amazonaws.com",
               "S3_BUCKET=ocp-odh-os-demo-s3",
               "AUTOMATION=1"


### PR DESCRIPTION
resolves #100 

In this PR
- I made modifications to documentation to use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
- Modified the pipelines to remove use of access and secret keys
- Added some details on using openshift secret.

Tested pipeline runs with the new setup
- demo1.pipeline - http://ml-pipeline-ui-kubeflow.apps.odh-cl1.apps.os-climate.org/pipeline/#/runs/details/5cf4fb45-842e-4de1-9dd5-b38747b5de72
- preprocessing.pipeline - current setup [fails](http://ml-pipeline-ui-kubeflow.apps.odh-cl1.apps.os-climate.org/pipeline/#/runs/details/453a84fa-6969-458b-beda-b77ac3670af6), issue #111, when modified to run on 1 pdf with openshift secret - http://ml-pipeline-ui-kubeflow.apps.odh-cl1.apps.os-climate.org/pipeline/#/runs/details/10dd31d9-d98e-4089-b5a1-76ae2d1d324b
- inference.pipeline - http://ml-pipeline-ui-kubeflow.apps.odh-cl1.apps.os-climate.org/pipeline/#/runs/details/4879fc94-8696-478c-ab7e-f92892fad387