### PR TITLE
Remove pipfile-requirements manager from .thoth.yaml

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -11,7 +11,6 @@ runtime_environments:
     recommendation_type: latest
 
 managers:
-  - name: pipfile-requirements
   - name: update
     configuration:
       labels: [bot]


### PR DESCRIPTION
Fixes: https://github.com/os-climate/aicoe-osc-demo/issues/207
Signed-off-by: Shreekara <sshreeka@redhat.com>