### PR TITLE
Changed the environment variable name to original in order to match with elyra pipeline

### DIFF
--- a/notebooks/demo2/create_results_table.ipynb
+++ b/notebooks/demo2/create_results_table.ipynb
@@ -93,10 +93,10 @@
    "source": [
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
-    "    s3_endpoint_url=os.getenv(\"S3_LANDING_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_LANDING_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_LANDING_SECRET_KEY\"),\n",
-    "    s3_bucket=os.getenv(\"S3_LANDING_BUCKET\"),\n",
+    "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
+    "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]
   },

--- a/notebooks/demo2/infer_kpi.ipynb
+++ b/notebooks/demo2/infer_kpi.ipynb
@@ -96,10 +96,10 @@
    "source": [
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
-    "    s3_endpoint_url=os.getenv(\"S3_LANDING_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_LANDING_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_LANDING_SECRET_KEY\"),\n",
-    "    s3_bucket=os.getenv(\"S3_LANDING_BUCKET\"),\n",
+    "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
+    "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]
   },

--- a/notebooks/demo2/infer_relevance.ipynb
+++ b/notebooks/demo2/infer_relevance.ipynb
@@ -53,10 +53,10 @@
    "source": [
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
-    "    s3_endpoint_url=os.getenv(\"S3_LANDING_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_LANDING_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_LANDING_SECRET_KEY\"),\n",
-    "    s3_bucket=os.getenv(\"S3_LANDING_BUCKET\"),\n",
+    "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
+    "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]
   },

--- a/notebooks/demo2/pdf_text_extraction.ipynb
+++ b/notebooks/demo2/pdf_text_extraction.ipynb
@@ -120,10 +120,10 @@
    "source": [
     "# init s3 connector\n",
     "s3c = S3Communication(\n",
-    "    s3_endpoint_url=os.getenv(\"S3_LANDING_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_LANDING_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_LANDING_SECRET_KEY\"),\n",
-    "    s3_bucket=os.getenv(\"S3_LANDING_BUCKET\"),\n",
+    "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
+    "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]
   },

--- a/notebooks/demo2/setup_experiments_default_pdfs.ipynb
+++ b/notebooks/demo2/setup_experiments_default_pdfs.ipynb
@@ -43,10 +43,10 @@
     "\n",
     "# S3 connecter for the bucket with source data\n",
     "s3c = S3Communication(\n",
-    "    s3_endpoint_url=os.getenv(\"S3_LANDING_ENDPOINT\"),\n",
-    "    aws_access_key_id=os.getenv(\"S3_LANDING_ACCESS_KEY\"),\n",
-    "    aws_secret_access_key=os.getenv(\"S3_LANDING_SECRET_KEY\"),\n",
-    "    s3_bucket=os.getenv(\"S3_LANDING_BUCKET\"),\n",
+    "    s3_endpoint_url=os.getenv(\"S3_ENDPOINT\"),\n",
+    "    aws_access_key_id=os.getenv(\"AWS_ACCESS_KEY_ID\"),\n",
+    "    aws_secret_access_key=os.getenv(\"AWS_SECRET_ACCESS_KEY\"),\n",
+    "    s3_bucket=os.getenv(\"S3_BUCKET\"),\n",
     ")"
    ]
   },


### PR DESCRIPTION
[Here](https://github.com/os-climate/aicoe-osc-demo/pull/219), we previously had adjusted the env variable names according to the format given in the [documentation](https://github.com/os-climate/os_c_data_commons/blob/main/docs/credentials.env). This turned out to be not in match with env variable names in elyra pipeline. Hence reverting it back to its original form. 